### PR TITLE
添加分号，修复linux下android studio因为不兼容而无法使用生成的pac文件的问题。

### DIFF
--- a/genpac/res/tpl-pac.js
+++ b/genpac/res/tpl-pac.js
@@ -22,7 +22,7 @@ function FindProxyForURL(url, host) {
 function testHost(host, index) {
     for (var i = 0; i < rules[index].length; i++) {
         for (var j = 0; j < rules[index][i].length; j++) {
-            lastRule = rules[index][i][j]
+            lastRule = rules[index][i][j];
             if (host == lastRule || host.endsWith('.' + lastRule))
                 return i % 2 == 0 ? 'DIRECT' : proxy;
         }


### PR DESCRIPTION
android studio 3.x linux因为这个分号的问题而无法使用pac文件