### PR TITLE
Fix quotation marks in generated pac file

### DIFF
--- a/genpac/res/tpl-pac-precise.js
+++ b/genpac/res/tpl-pac-precise.js
@@ -5,7 +5,7 @@
  * GFWList From: __GFWLIST_FROM__
  */
 
-var proxy = '__PROXY__';
+var proxy = "__PROXY__";
 var rules = __RULES__;
 
 var lastRule = '';

--- a/genpac/res/tpl-pac.js
+++ b/genpac/res/tpl-pac.js
@@ -5,7 +5,7 @@
  * GFWList From: __GFWLIST_FROM__
  */
 
-var proxy = '__PROXY__';
+var proxy = "__PROXY__";
 var rules = __RULES__;
 
 var lastRule = '';


### PR DESCRIPTION
一些程序，如Firefox，不能正确处理pac文件中单引号内的多项代理规则，比如 'SOCKS5 127.0.0.1:1089; SOCKS 127.0.0.1:1089' 会优先使用 SOCKS 代理而不是 SOCKS5 代理，将单引号改成双引号即可解决此问题。